### PR TITLE
Add BoundingBox2d.strictlyOverlaps

### DIFF
--- a/src/OpenSolid/BoundingBox2d.elm
+++ b/src/OpenSolid/BoundingBox2d.elm
@@ -430,14 +430,15 @@ alwaysFalse firstBox secondBox =
 
 
 {-| Check if one box overlaps another by less than, greater than or equal to a
-given amount. You could perform a tolerant collision check (one that only
-returns true only if the boxes overlap by at least some small finite amount,
-and ignores boxes that just barely touch each other) as
+given amount. For example, you could perform a tolerant collision check (one
+that only returns true only if the boxes overlap by at least some small finite
+amount, and ignores boxes that just barely touch each other) as
 
     boxesCollide =
         BoundingBox2d.overlappingBy GT 0.001 box1 box2
 
-(The [`Order`](http://package.elm-lang.org/packages/elm-lang/core/latest/Basics#Order)
+This can be read as "`box1` and `box2` are overlapping by greater than 0.001
+units". (The [`Order`](http://package.elm-lang.org/packages/elm-lang/core/latest/Basics#Order)
 type and its three values `LT`, `GT` and `EQ` are defined in Elm's `Basics`
 module so are available by default in any Elm program.)
 
@@ -530,14 +531,16 @@ overlappingBy order tolerance =
 
 
 {-| Check if one box is separated from another by less than, greater than or
-equal to a given amount. If you were performing clash detection between some
-objects, you could use `separatedBy` on those objects' bounding boxes as a quick
-check to see if the objects had a gap of at least 1 cm between them:
+equal to a given amount. For example, if you were performing clash detection
+between some objects, you could use `separatedBy` on those objects' bounding
+boxes as a quick check to see if the objects had a gap of at least 1 cm between
+them:
 
     safelySeparated =
         BoundingBox2d.separatedBy GT 0.01 box1 box2
 
-(The [`Order`](http://package.elm-lang.org/packages/elm-lang/core/latest/Basics#Order)
+This can be read as "`box1` and `box2` are separated by greater than 0.01
+units". (The [`Order`](http://package.elm-lang.org/packages/elm-lang/core/latest/Basics#Order)
 type and its three values `LT`, `GT` and `EQ` are defined in Elm's `Basics`
 module so are available by default in any Elm program.)
 

--- a/src/OpenSolid/BoundingBox2d.elm
+++ b/src/OpenSolid/BoundingBox2d.elm
@@ -431,7 +431,7 @@ alwaysFalse firstBox secondBox =
 
 {-| Check if one box overlaps another by less than, greater than or equal to a
 given amount. For example, you could perform a tolerant collision check (one
-that only returns true only if the boxes overlap by at least some small finite
+that only returns true if the boxes overlap by at least some small finite
 amount, and ignores boxes that just barely touch each other) as
 
     boxesCollide =

--- a/src/OpenSolid/BoundingBox2d.elm
+++ b/src/OpenSolid/BoundingBox2d.elm
@@ -453,9 +453,9 @@ negative number.
 
 ### Less than
 
-  - `overlappingBy LT 1e-3` will return true if the two boxes overlap by less than
-    0.001 units or if they do not overlap at all (false if they overlap by more
-    than 0.001 units).
+  - `overlappingBy LT 1e-3` will return true if the two boxes overlap by less
+    than 0.001 units or if they do not overlap at all (false if they overlap by
+    more than 0.001 units).
   - `overlappingBy LT 0` will return true only if the two boxes don't touch or
     overlap at all.
   - `overlappingBy LT -1e-3` will always return false! If you care about _how

--- a/src/OpenSolid/BoundingBox2d.elm
+++ b/src/OpenSolid/BoundingBox2d.elm
@@ -447,8 +447,8 @@ boxes.
 
 Boxes that just touch are considered to have an overlap of zero, which is
 distinct from 'no overlap'. Boxes that do not touch or overlap at all are
-considered to have an overlap which is less than zero but not greater or less
-than any negative number.
+considered to have an overlap which is less than zero but not comparable to any
+negative number.
 
 
 ### Less than
@@ -547,7 +547,7 @@ not touch.
 
 Boxes that just touch are considered to have a separation of zero, which is
 distinct from 'no separation'. 'No separation' (overlap) is considered to be
-less than zero but not greater or less than any negative number.
+less than zero but not comparable to any negative number.
 
 
 ### Less than

--- a/src/OpenSolid/BoundingBox2d.elm
+++ b/src/OpenSolid/BoundingBox2d.elm
@@ -500,6 +500,36 @@ given bounding boxes. If the given boxes do not intersect, returns `Nothing`.
     BoundingBox2d.intersection firstBox thirdBox
     --> Nothing
 
+If two boxes just touch along an edge or at a corner, they are still considered
+to have an intersection, even though that intersection will have zero area (at
+least one of its dimensions will be zero):
+
+    firstBox =
+        BoundingBox2d.with
+            { minX = 0
+            , maxX = 1
+            , minY = 0
+            , maxY = 2
+            }
+
+    secondBox =
+        BoundingBox2d.with
+            { minX = 1
+            , maxX = 2
+            , minY = 1
+            , maxY = 3
+            }
+
+    BoundingBox2d.intersection firstBox secondBox
+    --> Just
+    -->     (BoundingBox2d.with
+    -->         { minX = 1
+    -->         , maxX = 1
+    -->         , minY = 1
+    -->         , maxY = 2
+    -->         }
+    -->     )
+
 -}
 intersection : BoundingBox2d -> BoundingBox2d -> Maybe BoundingBox2d
 intersection firstBox secondBox =

--- a/src/OpenSolid/BoundingBox2d.elm
+++ b/src/OpenSolid/BoundingBox2d.elm
@@ -29,6 +29,7 @@ module OpenSolid.BoundingBox2d
         , minY
         , overlaps
         , singleton
+        , strictlyOverlaps
         , with
         )
 
@@ -354,6 +355,14 @@ overlaps other boundingBox =
         && (maxX boundingBox >= minX other)
         && (minY boundingBox <= maxY other)
         && (maxY boundingBox >= minY other)
+
+
+strictlyOverlaps : BoundingBox2d -> BoundingBox2d -> Bool
+strictlyOverlaps other boundingBox =
+    (minX boundingBox < maxX other)
+        && (maxX boundingBox > minX other)
+        && (minY boundingBox < maxY other)
+        && (maxY boundingBox > minY other)
 
 
 {-| Test if the second given bounding box is fully contained within the first

--- a/src/OpenSolid/BoundingBox2d.elm
+++ b/src/OpenSolid/BoundingBox2d.elm
@@ -435,7 +435,7 @@ returns true only if the boxes overlap by at least some small finite amount,
 and ignores boxes that just barely touch each other) as
 
     boxesCollide =
-        BoundingBox2d.overlappingBy GT 0.001 firstBox secondBox
+        BoundingBox2d.overlappingBy GT 0.001 box1 box2
 
 (The [`Order`](http://package.elm-lang.org/packages/elm-lang/core/latest/Basics#Order)
 type and its three values `LT`, `GT` and `EQ` are defined in Elm's `Basics`
@@ -535,7 +535,7 @@ objects, you could use `separatedBy` on those objects' bounding boxes as a quick
 check to see if the objects had a gap of at least 1 cm between them:
 
     safelySeparated =
-        BoundingBox2d.separatedBy GT 1.0e-2 firstBox secondBox
+        BoundingBox2d.separatedBy GT 0.01 box1 box2
 
 (The [`Order`](http://package.elm-lang.org/packages/elm-lang/core/latest/Basics#Order)
 type and its three values `LT`, `GT` and `EQ` are defined in Elm's `Basics`

--- a/src/OpenSolid/BoundingBox2d.elm
+++ b/src/OpenSolid/BoundingBox2d.elm
@@ -20,6 +20,7 @@ module OpenSolid.BoundingBox2d
         , hull
         , hullOf
         , intersection
+        , intersects
         , isContainedIn
         , maxX
         , maxY
@@ -316,7 +317,16 @@ contains point boundingBox =
     (minX <= x && x <= maxX) && (minY <= y && y <= maxY)
 
 
-{-| Test if one bounding box overlaps (touches) another.
+{-| Test if two boxes touch or overlap at all (have any points in common);
+
+    BoundingBox2d.intersects firstBox secondBox
+
+is equivalent to
+
+    BoundingBox2d.intersection firstBox secondBox
+        /= Nothing
+
+but is more efficient.
 
     firstBox =
         BoundingBox2d.with
@@ -342,15 +352,15 @@ contains point boundingBox =
             , maxY = 5
             }
 
-    BoundingBox2d.overlaps firstBox secondBox
+    BoundingBox2d.intersects firstBox secondBox
     --> True
 
-    BoundingBox2d.overlaps firstBox thirdBox
+    BoundingBox2d.intersects firstBox thirdBox
     --> False
 
 -}
-overlaps : BoundingBox2d -> BoundingBox2d -> Bool
-overlaps other boundingBox =
+intersects : BoundingBox2d -> BoundingBox2d -> Bool
+intersects other boundingBox =
     (minX boundingBox <= maxX other)
         && (maxX boundingBox >= minX other)
         && (minY boundingBox <= maxY other)
@@ -363,6 +373,14 @@ strictlyOverlaps other boundingBox =
         && (maxX boundingBox > minX other)
         && (minY boundingBox < maxY other)
         && (maxY boundingBox > minY other)
+{-| DEPRECATED: Alias for `intersects`, kept for compatibility. Use `intersects`
+instead.
+-}
+overlaps : BoundingBox2d -> BoundingBox2d -> Bool
+overlaps =
+    intersects
+
+
 
 
 {-| Test if the second given bounding box is fully contained within the first
@@ -443,7 +461,7 @@ hull firstBox secondBox =
 
 
 {-| Attempt to build a bounding box that contains all points common to both
-given bounding boxes. If the given boxes do not overlap, returns `Nothing`.
+given bounding boxes. If the given boxes do not intersect, returns `Nothing`.
 
     firstBox =
         BoundingBox2d.with
@@ -485,7 +503,7 @@ given bounding boxes. If the given boxes do not overlap, returns `Nothing`.
 -}
 intersection : BoundingBox2d -> BoundingBox2d -> Maybe BoundingBox2d
 intersection firstBox secondBox =
-    if overlaps firstBox secondBox then
+    if intersects firstBox secondBox then
         Just
             (with
                 { minX = max (minX firstBox) (minX secondBox)

--- a/src/OpenSolid/BoundingBox2d.elm
+++ b/src/OpenSolid/BoundingBox2d.elm
@@ -28,8 +28,8 @@ module OpenSolid.BoundingBox2d
         , midY
         , minX
         , minY
+        , overlappingBy
         , overlaps
-        , overlapsBy
         , scaleAbout
         , separatedBy
         , singleton
@@ -71,7 +71,7 @@ box of an object than the object itself, such as:
 
 # Queries
 
-@docs contains, isContainedIn, intersects, overlaps, overlapsBy, separatedBy
+@docs contains, isContainedIn, intersects, overlaps, overlappingBy, separatedBy
 
 
 # Transformations
@@ -435,7 +435,7 @@ returns true only if the boxes overlap by at least some small finite amount,
 and ignores boxes that just barely touch each other) as
 
     boxesCollide =
-        BoundingBox2d.overlapsBy GT 0.001 firstBox secondBox
+        BoundingBox2d.overlappingBy GT 0.001 firstBox secondBox
 
 (The [`Order`](http://package.elm-lang.org/packages/elm-lang/core/latest/Basics#Order)
 type and its three values `LT`, `GT` and `EQ` are defined in Elm's `Basics`
@@ -453,23 +453,23 @@ negative number.
 
 ### Less than
 
-  - `overlapsBy LT 1e-3` will return true if the two boxes overlap by less than
+  - `overlappingBy LT 1e-3` will return true if the two boxes overlap by less than
     0.001 units or if they do not overlap at all (false if they overlap by more
     than 0.001 units).
-  - `overlapsBy LT 0` will return true only if the two boxes don't touch or
+  - `overlappingBy LT 0` will return true only if the two boxes don't touch or
     overlap at all.
-  - `overlapsBy LT -1e-3` will always return false! If you care about _how much_
-    two boxes are separated by, use `separatedBy` instead.
+  - `overlappingBy LT -1e-3` will always return false! If you care about _how
+    much_ two boxes are separated by, use `separatedBy` instead.
 
 
 ### Greater than
 
-  - `overlapsBy GT 1e-3` will return true if the two boxes overlap by at least
-    0.001 units (false if they overlap by less than that or do not overlap at
-    all).
-  - `overlapsBy GT 0` will return true if the two boxes overlap by any non-zero
-    amount (false if they just touch or do not overlap at all).
-  - `overlapsBy GT -1e-3` doesn't make a lot of sense but will return true if
+  - `overlappingBy GT 1e-3` will return true if the two boxes overlap by at
+    least 0.001 units (false if they overlap by less than that or do not overlap
+    at all).
+  - `overlappingBy GT 0` will return true if the two boxes overlap by any
+    non-zero amount (false if they just touch or do not overlap at all).
+  - `overlappingBy GT -1e-3` doesn't make a lot of sense but will return true if
     the boxes touch or overlap at all (false if they don't overlap, regardless
     of how close they are to overlapping).
 
@@ -479,15 +479,15 @@ negative number.
 Checking whether two boxes overlap by exactly a given amount is pretty weird and
 vulnerable to floating-point roundoff, but is defined as follows:
 
-  - `overlapsBy EQ 1e-3` will return true if the two boxes overlap by exactly
+  - `overlappingBy EQ 1e-3` will return true if the two boxes overlap by exactly
     0.001 units.
-  - `overlapsBy EQ 0` will return true if and only if the boxes just touch each
-    other.
-  - `overlapsBy EQ -1e-3` will always return false.
+  - `overlappingBy EQ 0` will return true if and only if the boxes just touch
+    each other.
+  - `overlappingBy EQ -1e-3` will always return false.
 
 -}
-overlapsBy : Order -> Float -> BoundingBox2d -> BoundingBox2d -> Bool
-overlapsBy order tolerance =
+overlappingBy : Order -> Float -> BoundingBox2d -> BoundingBox2d -> Bool
+overlappingBy order tolerance =
     case order of
         LT ->
             if tolerance > 0 then
@@ -558,7 +558,7 @@ less than zero but not comparable to any negative number.
   - `separatedBy LT 0` will return true only if the boxes overlap by some
     non-zero amount.
   - `separatedBy LT -1e-3` will always return false! If you care about _how
-    much_ two boxes overlap by, use `overlapsBy` instead.
+    much_ two boxes overlap by, use `overlappingBy` instead.
 
 
 ### Greater than

--- a/src/OpenSolid/BoundingBox2d.elm
+++ b/src/OpenSolid/BoundingBox2d.elm
@@ -531,10 +531,9 @@ overlappingBy order tolerance =
 
 
 {-| Check if one box is separated from another by less than, greater than or
-equal to a given amount. For example, if you were performing clash detection
-between some objects, you could use `separatedBy` on those objects' bounding
-boxes as a quick check to see if the objects had a gap of at least 1 cm between
-them:
+equal to a given amount. For example, to perform clash detection between some
+objects, you could use `separatedBy` on those objects' bounding boxes as a quick
+check to see if the objects had a gap of at least 1 cm between them:
 
     safelySeparated =
         BoundingBox2d.separatedBy GT 0.01 box1 box2

--- a/src/OpenSolid/BoundingBox2d.elm
+++ b/src/OpenSolid/BoundingBox2d.elm
@@ -29,8 +29,9 @@ module OpenSolid.BoundingBox2d
         , minX
         , minY
         , overlaps
+        , overlapsBy
+        , separatedBy
         , singleton
-        , strictlyOverlaps
         , with
         )
 
@@ -68,7 +69,7 @@ box of an object than the object itself, such as:
 
 # Queries
 
-@docs contains, overlaps, isContainedIn
+@docs contains, isContainedIn, intersects, overlaps, overlapsBy, separatedBy
 
 -}
 
@@ -367,12 +368,6 @@ intersects other boundingBox =
         && (maxY boundingBox >= minY other)
 
 
-strictlyOverlaps : BoundingBox2d -> BoundingBox2d -> Bool
-strictlyOverlaps other boundingBox =
-    (minX boundingBox < maxX other)
-        && (maxX boundingBox > minX other)
-        && (minY boundingBox < maxY other)
-        && (maxY boundingBox > minY other)
 {-| DEPRECATED: Alias for `intersects`, kept for compatibility. Use `intersects`
 instead.
 -}
@@ -381,6 +376,248 @@ overlaps =
     intersects
 
 
+overlapAmount : BoundingBox2d -> BoundingBox2d -> Maybe Float
+overlapAmount firstBox secondBox =
+    let
+        xOverlap =
+            min (maxX firstBox) (maxX secondBox)
+                - max (minX firstBox) (minX secondBox)
+
+        yOverlap =
+            min (maxY firstBox) (maxY secondBox)
+                - max (minY firstBox) (minY secondBox)
+    in
+    if xOverlap >= 0 && yOverlap >= 0 then
+        Just (min xOverlap yOverlap)
+    else
+        Nothing
+
+
+squaredSeparationAmount : BoundingBox2d -> BoundingBox2d -> Maybe Float
+squaredSeparationAmount firstBox secondBox =
+    let
+        xSeparation =
+            max (minX firstBox) (minX secondBox)
+                - min (maxX firstBox) (maxX secondBox)
+
+        ySeparation =
+            max (minY firstBox) (minY secondBox)
+                - min (maxY firstBox) (maxY secondBox)
+    in
+    if xSeparation > 0 && ySeparation > 0 then
+        Just (xSeparation * xSeparation + ySeparation * ySeparation)
+    else if xSeparation > 0 then
+        Just (xSeparation * xSeparation)
+    else if ySeparation > 0 then
+        Just (ySeparation * ySeparation)
+    else if xSeparation == 0 || ySeparation == 0 then
+        Just 0
+    else
+        Nothing
+
+
+alwaysFalse : BoundingBox2d -> BoundingBox2d -> Bool
+alwaysFalse firstBox secondBox =
+    False
+
+
+{-| Check if one box overlaps another by less than, greater than or equal to a
+given amount. You could perform a tolerant collision check (one that only
+returns true only if the boxes overlap by at least some small finite amount,
+and ignores boxes that just barely touch each other) as
+
+    boxesCollide =
+        BoundingBox2d.overlapsBy GT 0.001 firstBox secondBox
+
+(The [`Order`](http://package.elm-lang.org/packages/elm-lang/core/latest/Basics#Order)
+type and its three values `LT`, `GT` and `EQ` are defined in Elm's `Basics`
+module so are available by default in any Elm program.)
+
+Overlap is defined as the _minimum_ distance one box would have to move so that
+it did not touch the other, and is always positive for any two overlapping
+boxes.
+
+Boxes that just touch are considered to have an overlap of zero, which is
+distinct from 'no overlap'. Boxes that do not touch or overlap at all are
+considered to have an overlap which is less than zero but not greater or less
+than any negative number.
+
+
+### Less than
+
+  - `overlapsBy LT 1e-3` will return true if the two boxes overlap by less than
+    0.001 units or if they do not overlap at all (false if they overlap by more
+    than 0.001 units).
+  - `overlapsBy LT 0` will return true only if the two boxes don't touch or
+    overlap at all.
+  - `overlapsBy LT -1e-3` will always return false! If you care about _how much_
+    two boxes are separated by, use `separatedBy` instead.
+
+
+### Greater than
+
+  - `overlapsBy GT 1e-3` will return true if the two boxes overlap by at least
+    0.001 units (false if they overlap by less than that or do not overlap at
+    all).
+  - `overlapsBy GT 0` will return true if the two boxes overlap by any non-zero
+    amount (false if they just touch or do not overlap at all).
+  - `overlapsBy GT -1e-3` doesn't make a lot of sense but will return true if
+    the boxes touch or overlap at all (false if they don't overlap, regardless
+    of how close they are to overlapping).
+
+
+### Equal to
+
+Checking whether two boxes overlap by exactly a given amount is pretty weird and
+vulnerable to floating-point roundoff, but is defined as follows:
+
+  - `overlapsBy EQ 1e-3` will return true if the two boxes overlap by exactly
+    0.001 units.
+  - `overlapsBy EQ 0` will return true if and only if the boxes just touch each
+    other.
+  - `overlapsBy EQ -1e-3` will always return false.
+
+-}
+overlapsBy : Order -> Float -> BoundingBox2d -> BoundingBox2d -> Bool
+overlapsBy order tolerance =
+    case order of
+        LT ->
+            if tolerance > 0 then
+                \firstBox secondBox ->
+                    case overlapAmount firstBox secondBox of
+                        Just distance ->
+                            distance < tolerance
+
+                        Nothing ->
+                            True
+            else if tolerance == 0 then
+                \firstBox secondBox ->
+                    overlapAmount firstBox secondBox == Nothing
+            else
+                alwaysFalse
+
+        GT ->
+            if tolerance >= 0 then
+                \firstBox secondBox ->
+                    case overlapAmount firstBox secondBox of
+                        Just distance ->
+                            distance > tolerance
+
+                        Nothing ->
+                            False
+            else
+                \firstBox secondBox ->
+                    overlapAmount firstBox secondBox /= Nothing
+
+        EQ ->
+            if tolerance >= 0 then
+                let
+                    expected =
+                        Just tolerance
+                in
+                \firstBox secondBox ->
+                    overlapAmount firstBox secondBox == expected
+            else
+                alwaysFalse
+
+
+{-| Check if one box is separated from another by less than, greater than or
+equal to a given amount. If you were performing clash detection between some
+objects, you could use `separatedBy` on those objects' bounding boxes as a quick
+check to see if the objects had a gap of at least 1 cm between them:
+
+    safelySeparated =
+        BoundingBox2d.separatedBy GT 1.0e-2 firstBox secondBox
+
+(The [`Order`](http://package.elm-lang.org/packages/elm-lang/core/latest/Basics#Order)
+type and its three values `LT`, `GT` and `EQ` are defined in Elm's `Basics`
+module so are available by default in any Elm program.)
+
+Separation is defined as the _minimum_ distance one box would have to move
+so that it touched the other, and is always positive for any two boxes that do
+not touch.
+
+Boxes that just touch are considered to have a separation of zero, which is
+distinct from 'no separation'. 'No separation' (overlap) is considered to be
+less than zero but not greater or less than any negative number.
+
+
+### Less than
+
+  - `separatedBy LT 1e-3` will return true if the two boxes are separated by
+    less than 0.001 units or if they touch or overlap (false if they are
+    separated by at least 0.001 units).
+  - `separatedBy LT 0` will return true only if the boxes overlap by some
+    non-zero amount.
+  - `separatedBy LT -1e-3` will always return false! If you care about _how
+    much_ two boxes overlap by, use `overlapsBy` instead.
+
+
+### Greater than
+
+  - `separatedBy GT 1e-3` will return true if the two boxes are separated by at
+    least 0.001 units (false if they are separated by less than that or if they
+    touch or overlap).
+  - `separatedBy GT 0` will return true if the two boxes are separated by any
+    non-zero amount (false if they touch or overlap).
+  - `separatedBy GT -1e-3` doesn't make a lot of sense but will return true if
+    the boxes just touch or are separated by any amount (false if they overlap
+    by any non-zero amount).
+
+
+### Equal to
+
+Checking whether two boxes are separated by exactly a given amount is pretty
+weird and vulnerable to floating-point roundoff, but is defined as follows:
+
+  - `separatedBy EQ 1e-3` will return true if the two boxes are separated by
+    exactly 0.001 units.
+  - `separatedBy EQ 0` will return true if and only if the boxes just touch each
+    other.
+  - `separatedBy EQ -3` will always return false.
+
+-}
+separatedBy : Order -> Float -> BoundingBox2d -> BoundingBox2d -> Bool
+separatedBy order tolerance =
+    case order of
+        LT ->
+            if tolerance > 0 then
+                \firstBox secondBox ->
+                    case squaredSeparationAmount firstBox secondBox of
+                        Just squaredDistance ->
+                            squaredDistance < tolerance * tolerance
+
+                        Nothing ->
+                            True
+            else if tolerance == 0 then
+                \firstBox secondBox ->
+                    squaredSeparationAmount firstBox secondBox == Nothing
+            else
+                alwaysFalse
+
+        GT ->
+            if tolerance >= 0 then
+                \firstBox secondBox ->
+                    case squaredSeparationAmount firstBox secondBox of
+                        Just squaredDistance ->
+                            squaredDistance > tolerance * tolerance
+
+                        Nothing ->
+                            False
+            else
+                \firstBox secondBox ->
+                    squaredSeparationAmount firstBox secondBox /= Nothing
+
+        EQ ->
+            if tolerance >= 0 then
+                let
+                    expected =
+                        Just (tolerance * tolerance)
+                in
+                \firstBox secondBox ->
+                    squaredSeparationAmount firstBox secondBox == expected
+            else
+                alwaysFalse
 
 
 {-| Test if the second given bounding box is fully contained within the first

--- a/src/OpenSolid/BoundingBox2d.elm
+++ b/src/OpenSolid/BoundingBox2d.elm
@@ -30,8 +30,10 @@ module OpenSolid.BoundingBox2d
         , minY
         , overlaps
         , overlapsBy
+        , scaleAbout
         , separatedBy
         , singleton
+        , translateBy
         , with
         )
 
@@ -71,11 +73,17 @@ box of an object than the object itself, such as:
 
 @docs contains, isContainedIn, intersects, overlaps, overlapsBy, separatedBy
 
+
+# Transformations
+
+@docs scaleAbout, translateBy
+
 -}
 
 import OpenSolid.Bootstrap.BoundingBox2d as Bootstrap
 import OpenSolid.Bootstrap.Point2d as Point2d
 import OpenSolid.Geometry.Internal as Internal exposing (Point2d)
+import OpenSolid.Vector2d as Vector2d exposing (Vector2d)
 
 
 {-| -}
@@ -781,3 +789,73 @@ intersection firstBox secondBox =
             )
     else
         Nothing
+
+
+{-| Scale a bounding box about a given point by a given scale.
+
+    point =
+        Point2d.fromCoordinates ( 4, 4 )
+
+    BoundingBox2d.scaleAbout point 2 exampleBox
+    --> BoundingBox2d.with
+    -->     { minX = 2
+    -->     , maxX = 12
+    -->     , minY = 0
+    -->     , maxY = 8
+    -->     }
+
+-}
+scaleAbout : Point2d -> Float -> BoundingBox2d -> BoundingBox2d
+scaleAbout point scale boundingBox =
+    let
+        { minX, minY, maxX, maxY } =
+            extrema boundingBox
+
+        ( x0, y0 ) =
+            Point2d.coordinates point
+    in
+    if scale >= 0 then
+        with
+            { minX = x0 + scale * (minX - x0)
+            , maxX = x0 + scale * (maxX - x0)
+            , minY = y0 + scale * (minY - y0)
+            , maxY = y0 + scale * (maxY - y0)
+            }
+    else
+        with
+            { minX = x0 + scale * (maxX - x0)
+            , maxX = x0 + scale * (minX - x0)
+            , minY = y0 + scale * (maxY - y0)
+            , maxY = y0 + scale * (minY - y0)
+            }
+
+
+{-| Translate a bounding box by a given displacement.
+
+    displacement =
+        Vector2d.fromComponents ( 2, -3 )
+
+    BoundingBox2d.translateBy displacement exampleBox
+    --> BoundingBox2d.with
+    -->     { minX = 5
+    -->     , maxX = 10
+    -->     , minY = -1
+    -->     , maxY = 3
+    -->     }
+
+-}
+translateBy : Vector2d -> BoundingBox2d -> BoundingBox2d
+translateBy displacement boundingBox =
+    let
+        { minX, minY, maxX, maxY } =
+            extrema boundingBox
+
+        ( dx, dy ) =
+            Vector2d.components displacement
+    in
+    with
+        { minX = minX + dx
+        , maxX = maxX + dx
+        , minY = minY + dy
+        , maxY = maxY + dy
+        }

--- a/src/OpenSolid/BoundingBox3d.elm
+++ b/src/OpenSolid/BoundingBox3d.elm
@@ -20,6 +20,7 @@ module OpenSolid.BoundingBox3d
         , hull
         , hullOf
         , intersection
+        , intersects
         , isContainedIn
         , maxX
         , maxY
@@ -68,7 +69,7 @@ box of an object than the object itself, such as:
 
 # Queries
 
-@docs contains, overlaps, isContainedIn
+@docs contains, isContainedIn, intersects, overlaps
 
 -}
 
@@ -376,7 +377,16 @@ contains point boundingBox =
         && (minZ <= z && z <= maxZ)
 
 
-{-| Test if one bounding box overlaps (touches) another.
+{-| Test if two boxes touch or overlap at all (have any points in common);
+
+    BoundingBox3d.intersects firstBox secondBox
+
+is equivalent to
+
+    BoundingBox3d.intersection firstBox secondBox
+        /= Nothing
+
+but is more efficient.
 
     firstBox =
         BoundingBox3d.with
@@ -408,21 +418,29 @@ contains point boundingBox =
             , maxZ = 2
             }
 
-    BoundingBox3d.overlaps firstBox secondBox
+    BoundingBox3d.intersects firstBox secondBox
     --> True
 
-    BoundingBox3d.overlaps firstBox thirdBox
+    BoundingBox3d.intersects firstBox thirdBox
     --> False
 
 -}
-overlaps : BoundingBox3d -> BoundingBox3d -> Bool
-overlaps other boundingBox =
+intersects : BoundingBox3d -> BoundingBox3d -> Bool
+intersects other boundingBox =
     (minX boundingBox <= maxX other)
         && (maxX boundingBox >= minX other)
         && (minY boundingBox <= maxY other)
         && (maxY boundingBox >= minY other)
         && (minZ boundingBox <= maxZ other)
         && (maxZ boundingBox >= minZ other)
+
+
+{-| DEPRECATED: Alias for `intersects`, kept for compatibility. Use `intersects`
+instead.
+-}
+overlaps : BoundingBox3d -> BoundingBox3d -> Bool
+overlaps =
+    intersects
 
 
 {-| Test if the second given bounding box is fully contained within the first
@@ -568,7 +586,7 @@ given bounding boxes. If the given boxes do not overlap, returns `Nothing`.
 -}
 intersection : BoundingBox3d -> BoundingBox3d -> Maybe BoundingBox3d
 intersection firstBox secondBox =
-    if overlaps firstBox secondBox then
+    if intersects firstBox secondBox then
         Just
             (with
                 { minX = max (minX firstBox) (minX secondBox)

--- a/src/OpenSolid/BoundingBox3d.elm
+++ b/src/OpenSolid/BoundingBox3d.elm
@@ -512,7 +512,7 @@ alwaysFalse firstBox secondBox =
 
 {-| Check if one box overlaps another by less than, greater than or equal to a
 given amount. For example, you could perform a tolerant collision check (one
-that only returns true only if the boxes overlap by at least some small finite
+that only returns true if the boxes overlap by at least some small finite
 amount, and ignores boxes that just barely touch each other) as
 
     boxesCollide =

--- a/src/OpenSolid/BoundingBox3d.elm
+++ b/src/OpenSolid/BoundingBox3d.elm
@@ -516,7 +516,7 @@ returns true only if the boxes overlap by at least some small finite amount,
 and ignores boxes that just barely touch each other) as
 
     boxesCollide =
-        BoundingBox3d.overlappingBy GT 0.001 firstBox secondBox
+        BoundingBox3d.overlappingBy GT 0.001 box1 box2
 
 (The [`Order`](http://package.elm-lang.org/packages/elm-lang/core/latest/Basics#Order)
 type and its three values `LT`, `GT` and `EQ` are defined in Elm's `Basics`
@@ -616,7 +616,7 @@ objects, you could use `separatedBy` on those objects' bounding boxes as a quick
 check to see if the objects had a gap of at least 1 cm between them:
 
     safelySeparated =
-        BoundingBox3d.separatedBy GT 1.0e-2 firstBox secondBox
+        BoundingBox3d.separatedBy GT 0.01 box1 box2
 
 (The [`Order`](http://package.elm-lang.org/packages/elm-lang/core/latest/Basics#Order)
 type and its three values `LT`, `GT` and `EQ` are defined in Elm's `Basics`

--- a/src/OpenSolid/BoundingBox3d.elm
+++ b/src/OpenSolid/BoundingBox3d.elm
@@ -612,10 +612,9 @@ overlappingBy order tolerance =
 
 
 {-| Check if one box is separated from another by less than, greater than or
-equal to a given amount. For example, if you were performing clash detection
-between some objects, you could use `separatedBy` on those objects' bounding
-boxes as a quick check to see if the objects had a gap of at least 1 cm between
-them:
+equal to a given amount. For example, to perform clash detection between some
+objects, you could use `separatedBy` on those objects' bounding boxes as a quick
+check to see if the objects had a gap of at least 1 cm between them:
 
     safelySeparated =
         BoundingBox3d.separatedBy GT 0.01 box1 box2

--- a/src/OpenSolid/BoundingBox3d.elm
+++ b/src/OpenSolid/BoundingBox3d.elm
@@ -511,14 +511,15 @@ alwaysFalse firstBox secondBox =
 
 
 {-| Check if one box overlaps another by less than, greater than or equal to a
-given amount. You could perform a tolerant collision check (one that only
-returns true only if the boxes overlap by at least some small finite amount,
-and ignores boxes that just barely touch each other) as
+given amount. For example, you could perform a tolerant collision check (one
+that only returns true only if the boxes overlap by at least some small finite
+amount, and ignores boxes that just barely touch each other) as
 
     boxesCollide =
         BoundingBox3d.overlappingBy GT 0.001 box1 box2
 
-(The [`Order`](http://package.elm-lang.org/packages/elm-lang/core/latest/Basics#Order)
+This can be read as "`box1` and `box2` are overlapping by greater than 0.001
+units". (The [`Order`](http://package.elm-lang.org/packages/elm-lang/core/latest/Basics#Order)
 type and its three values `LT`, `GT` and `EQ` are defined in Elm's `Basics`
 module so are available by default in any Elm program.)
 
@@ -611,14 +612,16 @@ overlappingBy order tolerance =
 
 
 {-| Check if one box is separated from another by less than, greater than or
-equal to a given amount. If you were performing clash detection between some
-objects, you could use `separatedBy` on those objects' bounding boxes as a quick
-check to see if the objects had a gap of at least 1 cm between them:
+equal to a given amount. For example, if you were performing clash detection
+between some objects, you could use `separatedBy` on those objects' bounding
+boxes as a quick check to see if the objects had a gap of at least 1 cm between
+them:
 
     safelySeparated =
         BoundingBox3d.separatedBy GT 0.01 box1 box2
 
-(The [`Order`](http://package.elm-lang.org/packages/elm-lang/core/latest/Basics#Order)
+This can be read as "`box1` and `box2` are separated by greater than 0.01
+units". (The [`Order`](http://package.elm-lang.org/packages/elm-lang/core/latest/Basics#Order)
 type and its three values `LT`, `GT` and `EQ` are defined in Elm's `Basics`
 module so are available by default in any Elm program.)
 

--- a/src/OpenSolid/BoundingBox3d.elm
+++ b/src/OpenSolid/BoundingBox3d.elm
@@ -32,7 +32,9 @@ module OpenSolid.BoundingBox3d
         , minY
         , minZ
         , overlaps
+        , scaleAbout
         , singleton
+        , translateBy
         , with
         )
 
@@ -71,11 +73,17 @@ box of an object than the object itself, such as:
 
 @docs contains, isContainedIn, intersects, overlaps
 
+
+# Transformations
+
+@docs scaleAbout, translateBy
+
 -}
 
 import OpenSolid.Bootstrap.BoundingBox3d as Bootstrap
 import OpenSolid.Bootstrap.Point3d as Point3d
 import OpenSolid.Geometry.Internal as Internal exposing (Point3d)
+import OpenSolid.Vector3d as Vector3d exposing (Vector3d)
 
 
 {-| -}
@@ -599,3 +607,83 @@ intersection firstBox secondBox =
             )
     else
         Nothing
+
+
+{-| Scale a bounding box about a given point by a given scale.
+
+    point =
+        Point3d.fromCoordinates ( 2, 2, 2 )
+
+    BoundingBox3d.scaleAbout point 2 exampleBox
+    --> BoundingBox3d.with
+    -->     { minX = -6
+    -->     , maxX = 2
+    -->     , minY = 2
+    -->     , maxY = 8
+    -->     , minZ = 4
+    -->     , maxZ = 6
+    -->     }
+
+-}
+scaleAbout : Point3d -> Float -> BoundingBox3d -> BoundingBox3d
+scaleAbout point scale boundingBox =
+    let
+        { minX, minY, minZ, maxX, maxY, maxZ } =
+            extrema boundingBox
+
+        ( x0, y0, z0 ) =
+            Point3d.coordinates point
+    in
+    if scale >= 0 then
+        with
+            { minX = x0 + scale * (minX - x0)
+            , maxX = x0 + scale * (maxX - x0)
+            , minY = y0 + scale * (minY - y0)
+            , maxY = y0 + scale * (maxY - y0)
+            , minZ = z0 + scale * (minZ - z0)
+            , maxZ = z0 + scale * (maxZ - z0)
+            }
+    else
+        with
+            { minX = x0 + scale * (maxX - x0)
+            , maxX = x0 + scale * (minX - x0)
+            , minY = y0 + scale * (maxY - y0)
+            , maxY = y0 + scale * (minY - y0)
+            , minZ = z0 + scale * (maxZ - z0)
+            , maxZ = z0 + scale * (minZ - z0)
+            }
+
+
+{-| Translate a bounding box by a given displacement.
+
+    displacement =
+        Vector3d.fromComponents ( 2, -3, 1 )
+
+    BoundingBox3d.translateBy displacement exampleBox
+    --> BoundingBox3d.with
+    -->     { minX = 0
+    -->     , maxX = 4
+    -->     , minY = -1
+    -->     , maxY = 2
+    -->     , minZ = 4
+    -->     , maxZ = 5
+    -->     }
+
+-}
+translateBy : Vector3d -> BoundingBox3d -> BoundingBox3d
+translateBy displacement boundingBox =
+    let
+        { minX, minY, minZ, maxX, maxY, maxZ } =
+            extrema boundingBox
+
+        ( dx, dy, dz ) =
+            Vector3d.components displacement
+    in
+    with
+        { minX = minX + dx
+        , maxX = maxX + dx
+        , minY = minY + dy
+        , maxY = maxY + dy
+        , minZ = minZ + dz
+        , maxZ = maxZ + dz
+        }

--- a/tests/BoundingBox2d.elm
+++ b/tests/BoundingBox2d.elm
@@ -3,11 +3,11 @@ module BoundingBox2d
         ( boxContainsOwnCentroid
         , hullContainsInputs
         , intersectionConsistentWithIntersects
-        , intersectionConsistentWithOverlapsBy
+        , intersectionConsistentWithOverlappingBy
         , intersectionIsValidOrNothing
         , jsonRoundTrips
         , overlappingBoxesCannotBySeparated
-        , overlapsByDetectsIntersection
+        , overlappingByDetectsIntersection
         , separatedBoxesCannotBeMadeToOverlap
         , separationIsCorrectForDiagonallyDisplacedBoxes
         , separationIsCorrectForHorizontallyDisplacedBoxes
@@ -72,16 +72,16 @@ intersectionConsistentWithIntersects =
         )
 
 
-intersectionConsistentWithOverlapsBy : Test
-intersectionConsistentWithOverlapsBy =
+intersectionConsistentWithOverlappingBy : Test
+intersectionConsistentWithOverlappingBy =
     Test.fuzz2
         Fuzz.boundingBox2d
         Fuzz.boundingBox2d
-        "'intersection' is consistent with 'overlapsBy'"
+        "'intersection' is consistent with 'overlappingBy'"
         (\first second ->
             let
-                overlaps =
-                    BoundingBox2d.overlapsBy GT 0 first second
+                overlapping =
+                    BoundingBox2d.overlappingBy GT 0 first second
 
                 intersection =
                     BoundingBox2d.intersection first second
@@ -89,7 +89,7 @@ intersectionConsistentWithOverlapsBy =
                 intersectionDimensions =
                     Maybe.map BoundingBox2d.dimensions intersection
             in
-            case ( overlaps, intersectionDimensions ) of
+            case ( overlapping, intersectionDimensions ) of
                 ( True, Just ( width, height ) ) ->
                     if width == 0 then
                         Expect.fail
@@ -190,21 +190,21 @@ boxContainsOwnCentroid =
         )
 
 
-overlapsByDetectsIntersection : Test
-overlapsByDetectsIntersection =
+overlappingByDetectsIntersection : Test
+overlappingByDetectsIntersection =
     Test.fuzz2
         Fuzz.boundingBox2d
         Fuzz.boundingBox2d
-        "overlapsBy LT 0 detects non-intersecting boxes"
+        "overlappingBy LT 0 detects non-intersecting boxes"
         (\firstBox secondBox ->
             case BoundingBox2d.intersection firstBox secondBox of
                 Just intersectionBox ->
                     Expect.false "intersecting boxes should overlap by at least 0"
-                        (BoundingBox2d.overlapsBy LT 0 firstBox secondBox)
+                        (BoundingBox2d.overlappingBy LT 0 firstBox secondBox)
 
                 Nothing ->
                     Expect.true "non-intersecting boxes should overlap by less than 0"
-                        (BoundingBox2d.overlapsBy LT 0 firstBox secondBox)
+                        (BoundingBox2d.overlappingBy LT 0 firstBox secondBox)
         )
 
 
@@ -220,7 +220,7 @@ overlappingBoxesCannotBySeparated =
                 tolerance =
                     Vector2d.length displacement
             in
-            if BoundingBox2d.overlapsBy GT tolerance firstBox secondBox then
+            if BoundingBox2d.overlappingBy GT tolerance firstBox secondBox then
                 BoundingBox2d.translateBy displacement firstBox
                     |> BoundingBox2d.intersects secondBox
                     |> Expect.true "displaced box should still intersect the other box"

--- a/tests/BoundingBox2d.elm
+++ b/tests/BoundingBox2d.elm
@@ -9,6 +9,9 @@ module BoundingBox2d
         , overlappingBoxesCannotBySeparated
         , overlapsByDetectsIntersection
         , separatedBoxesCannotBeMadeToOverlap
+        , separationIsCorrectForDiagonallyDisplacedBoxes
+        , separationIsCorrectForHorizontallyDisplacedBoxes
+        , separationIsCorrectForVerticallyDisplacedBoxes
         )
 
 import Expect
@@ -244,4 +247,85 @@ separatedBoxesCannotBeMadeToOverlap =
                     |> Expect.false "displaced box should still not intersect the other box"
             else
                 Expect.pass
+        )
+
+
+separationIsCorrectForHorizontallyDisplacedBoxes : Test
+separationIsCorrectForHorizontallyDisplacedBoxes =
+    Test.test
+        "separation is determined correctly for horizontally displaced boxes"
+        (\_ ->
+            let
+                firstBox =
+                    BoundingBox2d.with
+                        { minX = 0
+                        , minY = 0
+                        , maxX = 1
+                        , maxY = 1
+                        }
+
+                secondBox =
+                    BoundingBox2d.with
+                        { minX = 2
+                        , minY = 0
+                        , maxX = 3
+                        , maxY = 1
+                        }
+            in
+            BoundingBox2d.separatedBy EQ 1 firstBox secondBox
+                |> Expect.true "separation is equal to 1"
+        )
+
+
+separationIsCorrectForVerticallyDisplacedBoxes : Test
+separationIsCorrectForVerticallyDisplacedBoxes =
+    Test.test
+        "separation is determined correctly for vertically displaced boxes"
+        (\_ ->
+            let
+                firstBox =
+                    BoundingBox2d.with
+                        { minX = 0
+                        , minY = 0
+                        , maxX = 1
+                        , maxY = 1
+                        }
+
+                secondBox =
+                    BoundingBox2d.with
+                        { minX = 0
+                        , minY = 2
+                        , maxX = 1
+                        , maxY = 3
+                        }
+            in
+            BoundingBox2d.separatedBy EQ 1 firstBox secondBox
+                |> Expect.true "separation is equal to 1"
+        )
+
+
+separationIsCorrectForDiagonallyDisplacedBoxes : Test
+separationIsCorrectForDiagonallyDisplacedBoxes =
+    Test.test
+        "separation is determined correctly for diagonally displaced boxes"
+        (\_ ->
+            let
+                firstBox =
+                    BoundingBox2d.with
+                        { minX = 0
+                        , minY = 0
+                        , maxX = 1
+                        , maxY = 1
+                        }
+
+                secondBox =
+                    BoundingBox2d.with
+                        { minX = 4
+                        , minY = 5
+                        , maxX = 5
+                        , maxY = 6
+                        }
+            in
+            BoundingBox2d.separatedBy EQ 5 firstBox secondBox
+                |> Expect.true "separation is equal to 5"
         )

--- a/tests/BoundingBox2d.elm
+++ b/tests/BoundingBox2d.elm
@@ -273,7 +273,7 @@ separationIsCorrectForHorizontallyDisplacedBoxes =
                         }
             in
             BoundingBox2d.separatedBy EQ 1 firstBox secondBox
-                |> Expect.true "separation is equal to 1"
+                |> Expect.true "separation is not equal to 1"
         )
 
 
@@ -300,7 +300,7 @@ separationIsCorrectForVerticallyDisplacedBoxes =
                         }
             in
             BoundingBox2d.separatedBy EQ 1 firstBox secondBox
-                |> Expect.true "separation is equal to 1"
+                |> Expect.true "separation is not equal to 1"
         )
 
 
@@ -327,5 +327,5 @@ separationIsCorrectForDiagonallyDisplacedBoxes =
                         }
             in
             BoundingBox2d.separatedBy EQ 5 firstBox secondBox
-                |> Expect.true "separation is equal to 5"
+                |> Expect.true "separation is not equal to 5"
         )

--- a/tests/BoundingBox2d.elm
+++ b/tests/BoundingBox2d.elm
@@ -9,15 +9,11 @@ module BoundingBox2d
         )
 
 import Expect
-import Fuzz
 import Generic
-import Json.Decode as Decode
 import OpenSolid.BoundingBox2d as BoundingBox2d
 import OpenSolid.Geometry.Decode as Decode
 import OpenSolid.Geometry.Encode as Encode
-import OpenSolid.Geometry.Expect as Expect
 import OpenSolid.Geometry.Fuzz as Fuzz
-import OpenSolid.Point2d as Point2d
 import Test exposing (Test)
 
 

--- a/tests/BoundingBox2d.elm
+++ b/tests/BoundingBox2d.elm
@@ -3,6 +3,7 @@ module BoundingBox2d
         ( boxContainsOwnCentroid
         , hullContainsInputs
         , intersectionConsistentWithOverlaps
+        , intersectionConsistentWithStrictlyOverlaps
         , intersectionIsValidOrNothing
         , jsonRoundTrips
         )
@@ -65,6 +66,68 @@ intersectionConsistentWithOverlaps =
                             ++ " but have valid intersection "
                             ++ toString intersectionBox
                         )
+        )
+
+
+intersectionConsistentWithStrictlyOverlaps : Test
+intersectionConsistentWithStrictlyOverlaps =
+    Test.fuzz2 Fuzz.boundingBox2d
+        Fuzz.boundingBox2d
+        "'intersection' is consistent with 'strictlyOverlaps'"
+        (\first second ->
+            let
+                strictlyOverlaps =
+                    BoundingBox2d.strictlyOverlaps first second
+
+                intersection =
+                    BoundingBox2d.intersection first second
+
+                intersectionDimensions =
+                    Maybe.map BoundingBox2d.dimensions intersection
+            in
+                case ( strictlyOverlaps, intersectionDimensions ) of
+                    ( True, Just ( width, height ) ) ->
+                        if width == 0 then
+                            Expect.fail
+                                (toString first
+                                    ++ " and "
+                                    ++ toString second
+                                    ++ " considered to strictly overlap, "
+                                    ++ "but intersection width is 0"
+                                )
+                        else if height == 0 then
+                            Expect.fail
+                                (toString first
+                                    ++ " and "
+                                    ++ toString second
+                                    ++ " considered to strictly overlap, "
+                                    ++ "but intersection height is 0"
+                                )
+                        else
+                            Expect.pass
+
+                    ( False, Nothing ) ->
+                        Expect.pass
+
+                    ( True, Nothing ) ->
+                        Expect.fail
+                            (toString first
+                                ++ " and "
+                                ++ toString second
+                                ++ " considered to strictly overlap, "
+                                ++ "but intersection is Nothing"
+                            )
+
+                    ( False, Just intersectionDimensions ) ->
+                        Expect.fail
+                            (toString first
+                                ++ " and "
+                                ++ toString second
+                                ++ " not considered to strictly overlap, "
+                                ++ "but have valid intersection "
+                                ++ "with dimensions "
+                                ++ toString intersectionDimensions
+                            )
         )
 
 

--- a/tests/BoundingBox2d.elm
+++ b/tests/BoundingBox2d.elm
@@ -77,7 +77,7 @@ intersectionConsistentWithStrictlyOverlaps =
         (\first second ->
             let
                 strictlyOverlaps =
-                    BoundingBox2d.strictlyOverlaps first second
+                    BoundingBox2d.overlapsBy GT 0 first second
 
                 intersection =
                     BoundingBox2d.intersection first second
@@ -85,47 +85,50 @@ intersectionConsistentWithStrictlyOverlaps =
                 intersectionDimensions =
                     Maybe.map BoundingBox2d.dimensions intersection
             in
-                case ( strictlyOverlaps, intersectionDimensions ) of
-                    ( True, Just ( width, height ) ) ->
-                        if width == 0 then
-                            Expect.fail
-                                (toString first
-                                    ++ " and "
-                                    ++ toString second
-                                    ++ " considered to strictly overlap, "
-                                    ++ "but intersection width is 0"
-                                )
-                        else if height == 0 then
-                            Expect.fail
-                                (toString first
-                                    ++ " and "
-                                    ++ toString second
-                                    ++ " considered to strictly overlap, "
-                                    ++ "but intersection height is 0"
-                                )
-                        else
-                            Expect.pass
-
-                    ( False, Nothing ) ->
-                        Expect.pass
-
-                    ( True, Nothing ) ->
+            case ( strictlyOverlaps, intersectionDimensions ) of
+                ( True, Just ( width, height ) ) ->
+                    if width == 0 then
                         Expect.fail
                             (toString first
                                 ++ " and "
                                 ++ toString second
                                 ++ " considered to strictly overlap, "
-                                ++ "but intersection is Nothing"
+                                ++ "but intersection width is 0"
                             )
+                    else if height == 0 then
+                        Expect.fail
+                            (toString first
+                                ++ " and "
+                                ++ toString second
+                                ++ " considered to strictly overlap, "
+                                ++ "but intersection height is 0"
+                            )
+                    else
+                        Expect.pass
 
-                    ( False, Just intersectionDimensions ) ->
+                ( False, Nothing ) ->
+                    Expect.pass
+
+                ( True, Nothing ) ->
+                    Expect.fail
+                        (toString first
+                            ++ " and "
+                            ++ toString second
+                            ++ " considered to strictly overlap, "
+                            ++ "but intersection is Nothing"
+                        )
+
+                ( False, Just ( width, height ) ) ->
+                    if height == 0 || width == 0 then
+                        Expect.pass
+                    else
                         Expect.fail
                             (toString first
                                 ++ " and "
                                 ++ toString second
                                 ++ " not considered to strictly overlap, "
                                 ++ "but have valid intersection "
-                                ++ "with dimensions "
+                                ++ "with non-zero dimensions "
                                 ++ toString intersectionDimensions
                             )
         )

--- a/tests/BoundingBox2d.elm
+++ b/tests/BoundingBox2d.elm
@@ -272,8 +272,27 @@ separationIsCorrectForHorizontallyDisplacedBoxes =
                         , maxY = 1
                         }
             in
-            BoundingBox2d.separatedBy EQ 1 firstBox secondBox
-                |> Expect.true "separation is not equal to 1"
+            firstBox
+                |> Expect.all
+                    [ Expect.true "Expected separation to be equal to 1"
+                        << BoundingBox2d.separatedBy EQ 1 secondBox
+                    , Expect.true "Expected separation to be greater than 0.5"
+                        << BoundingBox2d.separatedBy GT 0.5 secondBox
+                    , Expect.true "Expected separation to be greater than 0"
+                        << BoundingBox2d.separatedBy GT 0 secondBox
+                    , Expect.true "Expected separation to be greater than -1"
+                        << BoundingBox2d.separatedBy GT -1 secondBox
+                    , Expect.true "Expected separation to be less than 2"
+                        << BoundingBox2d.separatedBy LT 2 secondBox
+                    , Expect.false "Expected separation to not be equal to 2"
+                        << BoundingBox2d.separatedBy EQ 2 secondBox
+                    , Expect.false "Expected separation to not be greater than 1"
+                        << BoundingBox2d.separatedBy GT 1 secondBox
+                    , Expect.false "Expected separation to not be less than 1"
+                        << BoundingBox2d.separatedBy LT 1 secondBox
+                    , Expect.false "Expected separation to not be less than 0"
+                        << BoundingBox2d.separatedBy LT 0 secondBox
+                    ]
         )
 
 
@@ -299,8 +318,27 @@ separationIsCorrectForVerticallyDisplacedBoxes =
                         , maxY = 3
                         }
             in
-            BoundingBox2d.separatedBy EQ 1 firstBox secondBox
-                |> Expect.true "separation is not equal to 1"
+            firstBox
+                |> Expect.all
+                    [ Expect.true "Expected separation to be equal to 1"
+                        << BoundingBox2d.separatedBy EQ 1 secondBox
+                    , Expect.true "Expected separation to be greater than 0.5"
+                        << BoundingBox2d.separatedBy GT 0.5 secondBox
+                    , Expect.true "Expected separation to be greater than 0"
+                        << BoundingBox2d.separatedBy GT 0 secondBox
+                    , Expect.true "Expected separation to be greater than -1"
+                        << BoundingBox2d.separatedBy GT -1 secondBox
+                    , Expect.true "Expected separation to be less than 2"
+                        << BoundingBox2d.separatedBy LT 2 secondBox
+                    , Expect.false "Expected separation to not be equal to 2"
+                        << BoundingBox2d.separatedBy EQ 2 secondBox
+                    , Expect.false "Expected separation to not be greater than 1"
+                        << BoundingBox2d.separatedBy GT 1 secondBox
+                    , Expect.false "Expected separation to not be less than 1"
+                        << BoundingBox2d.separatedBy LT 1 secondBox
+                    , Expect.false "Expected separation to not be less than 0"
+                        << BoundingBox2d.separatedBy LT 0 secondBox
+                    ]
         )
 
 
@@ -326,6 +364,25 @@ separationIsCorrectForDiagonallyDisplacedBoxes =
                         , maxY = 6
                         }
             in
-            BoundingBox2d.separatedBy EQ 5 firstBox secondBox
-                |> Expect.true "separation is not equal to 5"
+            firstBox
+                |> Expect.all
+                    [ Expect.true "Expected separation to be equal to 5"
+                        << BoundingBox2d.separatedBy EQ 5 secondBox
+                    , Expect.true "Expected separation to be greater than 4"
+                        << BoundingBox2d.separatedBy GT 4 secondBox
+                    , Expect.true "Expected separation to be greater than 0"
+                        << BoundingBox2d.separatedBy GT 0 secondBox
+                    , Expect.true "Expected separation to be greater than -1"
+                        << BoundingBox2d.separatedBy GT -1 secondBox
+                    , Expect.true "Expected separation to be less than 6"
+                        << BoundingBox2d.separatedBy LT 6 secondBox
+                    , Expect.false "Expected separation to not be equal to 6"
+                        << BoundingBox2d.separatedBy EQ 6 secondBox
+                    , Expect.false "Expected separation to not be greater than 5"
+                        << BoundingBox2d.separatedBy GT 5 secondBox
+                    , Expect.false "Expected separation to not be less than 5"
+                        << BoundingBox2d.separatedBy LT 5 secondBox
+                    , Expect.false "Expected separation to not be less than 0"
+                        << BoundingBox2d.separatedBy LT 0 secondBox
+                    ]
         )

--- a/tests/BoundingBox2d.elm
+++ b/tests/BoundingBox2d.elm
@@ -2,8 +2,8 @@ module BoundingBox2d
     exposing
         ( boxContainsOwnCentroid
         , hullContainsInputs
-        , intersectionConsistentWithOverlaps
-        , intersectionConsistentWithStrictlyOverlaps
+        , intersectionConsistentWithIntersects
+        , intersectionConsistentWithOverlapsBy
         , intersectionIsValidOrNothing
         , jsonRoundTrips
         , overlappingBoxesCannotBySeparated
@@ -28,20 +28,20 @@ jsonRoundTrips =
         Decode.boundingBox2d
 
 
-intersectionConsistentWithOverlaps : Test
-intersectionConsistentWithOverlaps =
+intersectionConsistentWithIntersects : Test
+intersectionConsistentWithIntersects =
     Test.fuzz2 Fuzz.boundingBox2d
         Fuzz.boundingBox2d
-        "'intersection' is consistent with 'overlaps'"
+        "'intersection' is consistent with 'intersects'"
         (\first second ->
             let
-                overlaps =
-                    BoundingBox2d.overlaps first second
+                intersects =
+                    BoundingBox2d.intersects first second
 
                 intersection =
                     BoundingBox2d.intersection first second
             in
-            case ( overlaps, intersection ) of
+            case ( intersects, intersection ) of
                 ( True, Just _ ) ->
                     Expect.pass
 
@@ -53,7 +53,7 @@ intersectionConsistentWithOverlaps =
                         (toString first
                             ++ " and "
                             ++ toString second
-                            ++ " considered to overlap, "
+                            ++ " considered to intersect, "
                             ++ "but intersection is Nothing"
                         )
 
@@ -62,21 +62,22 @@ intersectionConsistentWithOverlaps =
                         (toString first
                             ++ " and "
                             ++ toString second
-                            ++ " not considered to overlap, "
+                            ++ " not considered to intersect, "
                             ++ " but have valid intersection "
                             ++ toString intersectionBox
                         )
         )
 
 
-intersectionConsistentWithStrictlyOverlaps : Test
-intersectionConsistentWithStrictlyOverlaps =
-    Test.fuzz2 Fuzz.boundingBox2d
+intersectionConsistentWithOverlapsBy : Test
+intersectionConsistentWithOverlapsBy =
+    Test.fuzz2
         Fuzz.boundingBox2d
-        "'intersection' is consistent with 'strictlyOverlaps'"
+        Fuzz.boundingBox2d
+        "'intersection' is consistent with 'overlapsBy'"
         (\first second ->
             let
-                strictlyOverlaps =
+                overlaps =
                     BoundingBox2d.overlapsBy GT 0 first second
 
                 intersection =
@@ -85,7 +86,7 @@ intersectionConsistentWithStrictlyOverlaps =
                 intersectionDimensions =
                     Maybe.map BoundingBox2d.dimensions intersection
             in
-            case ( strictlyOverlaps, intersectionDimensions ) of
+            case ( overlaps, intersectionDimensions ) of
                 ( True, Just ( width, height ) ) ->
                     if width == 0 then
                         Expect.fail

--- a/tests/BoundingBox3d.elm
+++ b/tests/BoundingBox3d.elm
@@ -31,16 +31,16 @@ intersectionConsistentWithOverlaps : Test
 intersectionConsistentWithOverlaps =
     Test.fuzz2 Fuzz.boundingBox3d
         Fuzz.boundingBox3d
-        "'intersection' is consistent with 'overlaps'"
+        "'intersection' is consistent with 'intersects'"
         (\first second ->
             let
-                overlaps =
-                    BoundingBox3d.overlaps first second
+                intersects =
+                    BoundingBox3d.intersects first second
 
                 intersection =
                     BoundingBox3d.intersection first second
             in
-            case ( overlaps, intersection ) of
+            case ( intersects, intersection ) of
                 ( True, Just _ ) ->
                     Expect.pass
 
@@ -52,7 +52,7 @@ intersectionConsistentWithOverlaps =
                         (toString first
                             ++ " and "
                             ++ toString second
-                            ++ " considered to overlap, "
+                            ++ " considered to intersect, "
                             ++ "but intersection is Nothing"
                         )
 
@@ -61,7 +61,7 @@ intersectionConsistentWithOverlaps =
                         (toString first
                             ++ " and "
                             ++ toString second
-                            ++ " not considered to overlap, "
+                            ++ " not considered to intersect, "
                             ++ " but have valid intersection "
                             ++ toString intersectionBox
                         )

--- a/tests/BoundingBox3d.elm
+++ b/tests/BoundingBox3d.elm
@@ -2,7 +2,7 @@ module BoundingBox3d
     exposing
         ( boxContainsOwnCentroid
         , hullContainsInputs
-        , intersectionConsistentWithOverlaps
+        , intersectionConsistentWithIntersects
         , intersectionIsValidOrNothing
         , jsonRoundTrips
         )
@@ -27,8 +27,8 @@ jsonRoundTrips =
         Decode.boundingBox3d
 
 
-intersectionConsistentWithOverlaps : Test
-intersectionConsistentWithOverlaps =
+intersectionConsistentWithIntersects : Test
+intersectionConsistentWithIntersects =
     Test.fuzz2 Fuzz.boundingBox3d
         Fuzz.boundingBox3d
         "'intersection' is consistent with 'intersects'"

--- a/tests/BoundingBox3d.elm
+++ b/tests/BoundingBox3d.elm
@@ -3,20 +3,24 @@ module BoundingBox3d
         ( boxContainsOwnCentroid
         , hullContainsInputs
         , intersectionConsistentWithIntersects
+        , intersectionConsistentWithOverlappingBy
         , intersectionIsValidOrNothing
         , jsonRoundTrips
+        , overlappingBoxesCannotBySeparated
+        , overlappingByDetectsIntersection
+        , separatedBoxesCannotBeMadeToOverlap
+        , separationIsCorrectForDiagonallyDisplacedBoxes
+        , separationIsCorrectForHorizontallyDisplacedBoxes
+        , separationIsCorrectForVerticallyDisplacedBoxes
         )
 
 import Expect
-import Fuzz
 import Generic
-import Json.Decode as Decode
 import OpenSolid.BoundingBox3d as BoundingBox3d
 import OpenSolid.Geometry.Decode as Decode
 import OpenSolid.Geometry.Encode as Encode
-import OpenSolid.Geometry.Expect as Expect
 import OpenSolid.Geometry.Fuzz as Fuzz
-import OpenSolid.Point3d as Point3d
+import OpenSolid.Vector3d as Vector3d
 import Test exposing (Test)
 
 
@@ -65,6 +69,80 @@ intersectionConsistentWithIntersects =
                             ++ " but have valid intersection "
                             ++ toString intersectionBox
                         )
+        )
+
+
+intersectionConsistentWithOverlappingBy : Test
+intersectionConsistentWithOverlappingBy =
+    Test.fuzz2
+        Fuzz.boundingBox3d
+        Fuzz.boundingBox3d
+        "'intersection' is consistent with 'overlappingBy'"
+        (\first second ->
+            let
+                overlapping =
+                    BoundingBox3d.overlappingBy GT 0 first second
+
+                intersection =
+                    BoundingBox3d.intersection first second
+
+                intersectionDimensions =
+                    Maybe.map BoundingBox3d.dimensions intersection
+            in
+            case ( overlapping, intersectionDimensions ) of
+                ( True, Just ( length, width, height ) ) ->
+                    if length == 0 then
+                        Expect.fail
+                            (toString first
+                                ++ " and "
+                                ++ toString second
+                                ++ " considered to strictly overlap, "
+                                ++ "but intersection length is 0"
+                            )
+                    else if width == 0 then
+                        Expect.fail
+                            (toString first
+                                ++ " and "
+                                ++ toString second
+                                ++ " considered to strictly overlap, "
+                                ++ "but intersection width is 0"
+                            )
+                    else if height == 0 then
+                        Expect.fail
+                            (toString first
+                                ++ " and "
+                                ++ toString second
+                                ++ " considered to strictly overlap, "
+                                ++ "but intersection height is 0"
+                            )
+                    else
+                        Expect.pass
+
+                ( False, Nothing ) ->
+                    Expect.pass
+
+                ( True, Nothing ) ->
+                    Expect.fail
+                        (toString first
+                            ++ " and "
+                            ++ toString second
+                            ++ " considered to strictly overlap, "
+                            ++ "but intersection is Nothing"
+                        )
+
+                ( False, Just ( length, width, height ) ) ->
+                    if length == 0 || height == 0 || width == 0 then
+                        Expect.pass
+                    else
+                        Expect.fail
+                            (toString first
+                                ++ " and "
+                                ++ toString second
+                                ++ " not considered to strictly overlap, "
+                                ++ "but have valid intersection "
+                                ++ "with non-zero dimensions "
+                                ++ toString intersectionDimensions
+                            )
         )
 
 
@@ -117,4 +195,214 @@ boxContainsOwnCentroid =
             in
             Expect.true "bounding box does not contain its own centroid"
                 (BoundingBox3d.contains centroid box)
+        )
+
+
+overlappingByDetectsIntersection : Test
+overlappingByDetectsIntersection =
+    Test.fuzz2
+        Fuzz.boundingBox3d
+        Fuzz.boundingBox3d
+        "overlappingBy LT 0 detects non-intersecting boxes"
+        (\firstBox secondBox ->
+            case BoundingBox3d.intersection firstBox secondBox of
+                Just intersectionBox ->
+                    Expect.false "intersecting boxes should overlap by at least 0"
+                        (BoundingBox3d.overlappingBy LT 0 firstBox secondBox)
+
+                Nothing ->
+                    Expect.true "non-intersecting boxes should overlap by less than 0"
+                        (BoundingBox3d.overlappingBy LT 0 firstBox secondBox)
+        )
+
+
+overlappingBoxesCannotBySeparated : Test
+overlappingBoxesCannotBySeparated =
+    Test.fuzz3
+        Fuzz.boundingBox3d
+        Fuzz.boundingBox3d
+        Fuzz.vector3d
+        "boxes overlapping by greater than a distance cannot be separated by moving that distance"
+        (\firstBox secondBox displacement ->
+            let
+                tolerance =
+                    Vector3d.length displacement
+            in
+            if BoundingBox3d.overlappingBy GT tolerance firstBox secondBox then
+                BoundingBox3d.translateBy displacement firstBox
+                    |> BoundingBox3d.intersects secondBox
+                    |> Expect.true "displaced box should still intersect the other box"
+            else
+                Expect.pass
+        )
+
+
+separatedBoxesCannotBeMadeToOverlap : Test
+separatedBoxesCannotBeMadeToOverlap =
+    Test.fuzz3
+        Fuzz.boundingBox3d
+        Fuzz.boundingBox3d
+        Fuzz.vector3d
+        "boxes separated by greater than a distance cannot be made to overlap by moving that distance"
+        (\firstBox secondBox displacement ->
+            let
+                tolerance =
+                    Vector3d.length displacement
+            in
+            if BoundingBox3d.separatedBy GT tolerance firstBox secondBox then
+                BoundingBox3d.translateBy displacement firstBox
+                    |> BoundingBox3d.intersects secondBox
+                    |> Expect.false "displaced box should still not intersect the other box"
+            else
+                Expect.pass
+        )
+
+
+separationIsCorrectForHorizontallyDisplacedBoxes : Test
+separationIsCorrectForHorizontallyDisplacedBoxes =
+    Test.test
+        "separation is determined correctly for horizontally displaced boxes"
+        (\_ ->
+            let
+                firstBox =
+                    BoundingBox3d.with
+                        { minX = 0
+                        , minY = 0
+                        , minZ = 0
+                        , maxX = 1
+                        , maxY = 1
+                        , maxZ = 1
+                        }
+
+                secondBox =
+                    BoundingBox3d.with
+                        { minX = 2
+                        , minY = 0
+                        , minZ = 0
+                        , maxX = 3
+                        , maxY = 1
+                        , maxZ = 1
+                        }
+            in
+            firstBox
+                |> Expect.all
+                    [ Expect.true "Expected separation to be equal to 1"
+                        << BoundingBox3d.separatedBy EQ 1 secondBox
+                    , Expect.true "Expected separation to be greater than 0.5"
+                        << BoundingBox3d.separatedBy GT 0.5 secondBox
+                    , Expect.true "Expected separation to be greater than 0"
+                        << BoundingBox3d.separatedBy GT 0 secondBox
+                    , Expect.true "Expected separation to be greater than -1"
+                        << BoundingBox3d.separatedBy GT -1 secondBox
+                    , Expect.true "Expected separation to be less than 2"
+                        << BoundingBox3d.separatedBy LT 2 secondBox
+                    , Expect.false "Expected separation to not be equal to 2"
+                        << BoundingBox3d.separatedBy EQ 2 secondBox
+                    , Expect.false "Expected separation to not be greater than 1"
+                        << BoundingBox3d.separatedBy GT 1 secondBox
+                    , Expect.false "Expected separation to not be less than 1"
+                        << BoundingBox3d.separatedBy LT 1 secondBox
+                    , Expect.false "Expected separation to not be less than 0"
+                        << BoundingBox3d.separatedBy LT 0 secondBox
+                    ]
+        )
+
+
+separationIsCorrectForVerticallyDisplacedBoxes : Test
+separationIsCorrectForVerticallyDisplacedBoxes =
+    Test.test
+        "separation is determined correctly for vertically displaced boxes"
+        (\_ ->
+            let
+                firstBox =
+                    BoundingBox3d.with
+                        { minX = 0
+                        , minY = 0
+                        , minZ = 0
+                        , maxX = 1
+                        , maxY = 1
+                        , maxZ = 1
+                        }
+
+                secondBox =
+                    BoundingBox3d.with
+                        { minX = 0
+                        , minY = 0
+                        , minZ = 2
+                        , maxX = 1
+                        , maxY = 1
+                        , maxZ = 3
+                        }
+            in
+            firstBox
+                |> Expect.all
+                    [ Expect.true "Expected separation to be equal to 1"
+                        << BoundingBox3d.separatedBy EQ 1 secondBox
+                    , Expect.true "Expected separation to be greater than 0.5"
+                        << BoundingBox3d.separatedBy GT 0.5 secondBox
+                    , Expect.true "Expected separation to be greater than 0"
+                        << BoundingBox3d.separatedBy GT 0 secondBox
+                    , Expect.true "Expected separation to be greater than -1"
+                        << BoundingBox3d.separatedBy GT -1 secondBox
+                    , Expect.true "Expected separation to be less than 2"
+                        << BoundingBox3d.separatedBy LT 2 secondBox
+                    , Expect.false "Expected separation to not be equal to 2"
+                        << BoundingBox3d.separatedBy EQ 2 secondBox
+                    , Expect.false "Expected separation to not be greater than 1"
+                        << BoundingBox3d.separatedBy GT 1 secondBox
+                    , Expect.false "Expected separation to not be less than 1"
+                        << BoundingBox3d.separatedBy LT 1 secondBox
+                    , Expect.false "Expected separation to not be less than 0"
+                        << BoundingBox3d.separatedBy LT 0 secondBox
+                    ]
+        )
+
+
+separationIsCorrectForDiagonallyDisplacedBoxes : Test
+separationIsCorrectForDiagonallyDisplacedBoxes =
+    Test.test
+        "separation is determined correctly for diagonally displaced boxes"
+        (\_ ->
+            let
+                firstBox =
+                    BoundingBox3d.with
+                        { minX = 0
+                        , minY = 0
+                        , minZ = 0
+                        , maxX = 1
+                        , maxY = 1
+                        , maxZ = 1
+                        }
+
+                secondBox =
+                    BoundingBox3d.with
+                        { minX = 2
+                        , minY = 3
+                        , minZ = 3
+                        , maxX = 4
+                        , maxY = 5
+                        , maxZ = 6
+                        }
+            in
+            firstBox
+                |> Expect.all
+                    [ Expect.true "Expected separation to be equal to 3"
+                        << BoundingBox3d.separatedBy EQ 3 secondBox
+                    , Expect.true "Expected separation to be greater than 2"
+                        << BoundingBox3d.separatedBy GT 2 secondBox
+                    , Expect.true "Expected separation to be greater than 0"
+                        << BoundingBox3d.separatedBy GT 0 secondBox
+                    , Expect.true "Expected separation to be greater than -1"
+                        << BoundingBox3d.separatedBy GT -1 secondBox
+                    , Expect.true "Expected separation to be less than 4"
+                        << BoundingBox3d.separatedBy LT 4 secondBox
+                    , Expect.false "Expected separation to not be equal to 4"
+                        << BoundingBox3d.separatedBy EQ 4 secondBox
+                    , Expect.false "Expected separation to not be greater than 3"
+                        << BoundingBox3d.separatedBy GT 3 secondBox
+                    , Expect.false "Expected separation to not be less than 3"
+                        << BoundingBox3d.separatedBy LT 3 secondBox
+                    , Expect.false "Expected separation to not be less than 0"
+                        << BoundingBox3d.separatedBy LT 0 secondBox
+                    ]
         )


### PR DESCRIPTION
Hello hello 👋

Following up on our quick thought exchange on Slack, I figured I’d propose a new function checking whether or not a bounding box overlaps another strictly – i.e. shares an area with the other, as opposed to just sharing an edge or corner.

This is useful for many collision detection scenarios, where you don’t care whether or not one object is placed next to another, but don’t want to allow one to penetrate the other.

For my use case (which more or less matches the scenario that I described above), calculating this in application code was possible through a combination of `BoundingBox2d.intersection`. But the code would be far from elegant or idiomatic.