### PR TITLE
Update elm-verify-examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ documentation.json
 docs.json
 
 # elm-verify-examples generated tests
-tests/Doc
+tests/VerifyExamples
 
 # =========================
 # Operating System Files

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
 install:
   - node --version
   - npm --version
-  - npm install -g elm@$ELM_VERSION elm-test elm-verify-examples@1.0.2
+  - npm install -g elm@$ELM_VERSION elm-test elm-verify-examples
   - git clone https://github.com/NoRedInk/elm-ops-tooling
   - elm-ops-tooling/with_retry.rb elm package install --yes
   # Faster compile on Travis.
@@ -34,6 +34,8 @@ install:
     fi
 
 script:
-  - $TRAVIS_BUILD_DIR/sysconfcpus/bin/sysconfcpus -n 2 elm-verify-examples
-  - sed -i "s/Expect.equal/Expect.equalWithinTolerance/" tests/Doc/OpenSolid/*
-  - $TRAVIS_BUILD_DIR/sysconfcpus/bin/sysconfcpus -n 2 elm-test
+  # elm-test is called from elm-verify-examples automatically
+  # as some modifications to the generated tests are required 
+  # elm-verify-examples is instructed to use the wrapper 'elm-test-wrapper.sh' instead
+  # which does those modifications and then calls elm-test
+  - $TRAVIS_BUILD_DIR/sysconfcpus/bin/sysconfcpus -n 2 elm-verify-examples --elm-test=./elm-test-wrapper.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
 install:
   - node --version
   - npm --version
-  - npm install -g elm@$ELM_VERSION elm-test elm-verify-examples
+  - npm install -g elm@$ELM_VERSION elm-test elm-verify-examples@2.2.0
   - git clone https://github.com/NoRedInk/elm-ops-tooling
   - elm-ops-tooling/with_retry.rb elm package install --yes
   # Faster compile on Travis.

--- a/elm-test-wrapper.sh
+++ b/elm-test-wrapper.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+SCRIPT_DIR="`dirname $0`"
+find $SCRIPT_DIR/tests/VerifyExamples -type f -exec sed -i "s/Expect.equal/Expect.equalWithinTolerance/" {} \;
+elm-test

--- a/src/OpenSolid/Sphere3d.elm
+++ b/src/OpenSolid/Sphere3d.elm
@@ -144,10 +144,9 @@ Returns `Nothing` if four given points are coplanar.
         , Point3d.fromCoordinates ( 0, 0, 0.5 )
         )
     --> Just <| Sphere3d.with
-        { centerPoint =
-            Point3d.fromCoordinates ( 0, 0, -0.75 )
-            , radius = 1.25
-            }
+    -->     { centerPoint = Point3d.fromCoordinates ( 0, 0, -0.75 )
+    -->     , radius = 1.25
+    --> }
 
     Sphere3d.throughPoints
         ( Point3d.fromCoordinates ( 1, 0, 0 )
@@ -315,11 +314,7 @@ rotateAround axis angle sphere =
 
 {-| Translate a sphere by a given displacement.
 
-    displacement : Vector3d
-    displacement =
-        Vector3d.fromComponents ( 2, 1, 3 )
-
-    Sphere3d.translateBy displacement exampleSphere
+    Sphere3d.translateBy (Vector3d.fromComponents ( 2, 1, 3 )) exampleSphere
     --> Sphere3d.with
     -->     { centerPoint =
     -->         Point3d.fromCoordinates ( 3, 3, 4 )
@@ -360,12 +355,7 @@ mirrorAcross plane sphere =
 {-| Take a sphere defined in global coordinates, and return it expressed in
 local coordinates relative to a given reference frame.
 
-    localFrame : Frame3d
-    localFrame =
-        Frame3d.atPoint
-            (Point3d.fromCoordinates ( 1, 2, 3 ))
-
-    Sphere3d.relativeTo localFrame exampleSphere
+    Sphere3d.relativeTo (Frame3d.atPoint (Point3d.fromCoordinates ( 1, 2, 3 ))) exampleSphere
     --> Sphere3d.with
     -->     { centerPoint =
     -->         Point3d.fromCoordinates ( 0, 0, -2 )
@@ -384,12 +374,7 @@ relativeTo frame sphere =
 {-| Take a sphere considered to be defined in local coordinates relative to a
 given reference frame, and return that sphere expressed in global coordinates.
 
-    localFrame : Frame3d
-    localFrame =
-        Frame3d.atPoint
-            (Point3d.fromCoordinates ( 1, 2, 3 ))
-
-    Sphere3d.placeIn localFrame exampleSphere
+    Sphere3d.placeIn (Frame3d.atPoint (Point3d.fromCoordinates ( 1, 2, 3 ))) exampleSphere
     --> Sphere3d.with
     -->     { centerPoint =
     -->         Point3d.fromCoordinates ( 2, 4, 4 )

--- a/src/OpenSolid/Sphere3d.elm
+++ b/src/OpenSolid/Sphere3d.elm
@@ -144,7 +144,8 @@ Returns `Nothing` if four given points are coplanar.
         , Point3d.fromCoordinates ( 0, 0, 0.5 )
         )
     --> Just <| Sphere3d.with
-    -->     { centerPoint = Point3d.fromCoordinates ( 0, 0, -0.75 )
+    -->     { centerPoint =
+    -->         Point3d.fromCoordinates ( 0, 0, -0.75 )
     -->     , radius = 1.25
     --> }
 
@@ -314,7 +315,9 @@ rotateAround axis angle sphere =
 
 {-| Translate a sphere by a given displacement.
 
-    Sphere3d.translateBy (Vector3d.fromComponents ( 2, 1, 3 )) exampleSphere
+    exampleSphere
+        |> Sphere3d.translateBy
+            (Vector3d.fromComponents ( 2, 1, 3 ))
     --> Sphere3d.with
     -->     { centerPoint =
     -->         Point3d.fromCoordinates ( 3, 3, 4 )
@@ -355,7 +358,11 @@ mirrorAcross plane sphere =
 {-| Take a sphere defined in global coordinates, and return it expressed in
 local coordinates relative to a given reference frame.
 
-    Sphere3d.relativeTo (Frame3d.atPoint (Point3d.fromCoordinates ( 1, 2, 3 ))) exampleSphere
+    exampleSphere
+        |> Sphere3d.relativeTo
+            (Frame3d.atPoint
+                (Point3d.fromCoordinates ( 1, 2, 3 ))
+            )
     --> Sphere3d.with
     -->     { centerPoint =
     -->         Point3d.fromCoordinates ( 0, 0, -2 )
@@ -374,7 +381,11 @@ relativeTo frame sphere =
 {-| Take a sphere considered to be defined in local coordinates relative to a
 given reference frame, and return that sphere expressed in global coordinates.
 
-    Sphere3d.placeIn (Frame3d.atPoint (Point3d.fromCoordinates ( 1, 2, 3 ))) exampleSphere
+    exampleSphere
+        |> Sphere3d.placeIn
+            (Frame3d.atPoint
+                (Point3d.fromCoordinates ( 1, 2, 3 ))
+            )
     --> Sphere3d.with
     -->     { centerPoint =
     -->         Point3d.fromCoordinates ( 2, 4, 4 )


### PR DESCRIPTION

The update of elm-verify-examples broke the current setup for various
reasons:

- Change of generated test location 

- Automatically calls elm-test now  
  => Fixed by wrapper script that does the necessary replacements and then calls elm-test

- Examples that depend on intermediary definitions (like localFrame in the example for relativeTo)
  get put into their own files.

  As the imports in elm-verify-examples aren't file wide, putting them at the top of Sphere3d into an example only worked because elm-verify-examples used to stuff all examples from one source file into one test file.

  Now the comment with the required imports only gets included in the other examples, which do not contain any intermediary definitions as well.

  => Fixed *for now* by removing those intermediary definitions which results in all examples being put into one file.

- Some change in the parser for multi-line examples.
  => It seems like all lines of a expected result have to be preceeded by '==>' now